### PR TITLE
FIX typo and formatting error

### DIFF
--- a/src/resumes/material-blue.vue
+++ b/src/resumes/material-blue.vue
@@ -41,7 +41,7 @@
                     </div>
                     <div class="text">
                         <h4>{{person.contact.phone}}</h4>
-                        <span>mobil</span>
+                        <span>mobile</span>
                     </div>
                 </div>
             </a>

--- a/src/resumes/material-dark.vue
+++ b/src/resumes/material-dark.vue
@@ -81,7 +81,7 @@
       </div>
       <div class="skill" v-for="skill in person.skills">
         <div class="right">
-          <span>{{skill.name}}</span>
+          <span>{{skill.name}}&nbsp;</span>
           <div class="progress">
             <div class="determinate" :style="'width: '+skill.level+'%;'">
               <i class="fa fa-circle"></i>


### PR DESCRIPTION
FIX typo "Mobil"->"Mobile" in file /src/resumes/material-blue.vue
FIX single letter skill name (such as C) appearing on skill level line instead of above it in file /src/resumes/material-black.vue