### PR TITLE
add support for list items in job description when experience.description is an array.

### DIFF
--- a/src/resumes/left-right.vue
+++ b/src/resumes/left-right.vue
@@ -18,7 +18,16 @@
         <span class="company"> {{experience.company}} </span>
         <span class="job-title"> {{experience.position}} </span>
         <span class="time-period"> {{experience.timeperiod}}</span>
-        <span class="job-description"> {{experience.description}} </span>
+        <span class="job-description"> 
+          <template v-if="Array.isArray(experience.description)">
+            <ul>
+              <li v-for="bullet in experience.description">{{bullet}}</li>
+            </ul>
+          </template>
+          <template v-else>
+            {{experience.description}}
+          </template>
+        </span>
       </div>
     </div>
     <div class="contact">
@@ -178,6 +187,9 @@ export default Vue.component('left-right', {
   .experience .experience-block span {
     width:100%;
     color:#616161;
+  }
+  .experience .experience-block span.job-description ul {
+    list-style-type:circle;
   }
   .experience .experience-block span.company {
     font-weight:bold;

--- a/src/resumes/material-dark.vue
+++ b/src/resumes/material-dark.vue
@@ -104,7 +104,14 @@
       <div class="headline">{{experience.position}} - {{experience.company}}</h3>
         <div class="subheadline">{{experience.timeperiod}}</div>
         <p class="info">
-          {{experience.description}}
+          <template v-if="Array.isArray(experience.description)">
+            <ul>
+              <li v-for="bullet in experience.description"><span class="experience-dash"> - </span>{{bullet}}</li>
+            </ul>
+          </template>
+          <template v-else>
+            {{experience.description}}
+          </template>
         </p>
       </div>
     </div>
@@ -282,6 +289,9 @@ h4 {
       display:block;
       font-size:15px;
       color:rgba(0,0,0,0.870588);
+      .experience-dash{
+        margin-right:6px;
+      }
     }
     .subheadline {
       color:rgba(0,0,0,0.541176);

--- a/src/resumes/oblique.vue
+++ b/src/resumes/oblique.vue
@@ -27,7 +27,15 @@
 
         <div class="row">
           <span class="time-period"> {{experience.timeperiod}}</span>
-          <span class="job-description">, {{experience.description}} </span>
+          <template v-if="Array.isArray(experience.description)">
+            <ul>
+              <li v-for="bullet in experience.description"><i class="material-icons">details</i> {{bullet}}</li>
+              <!-- <li v-for="bullet in experience.description"> {{bullet}}</li> -->
+            </ul>
+          </template>
+          <template v-else>
+            <span class="job-description">, {{experience.description}} </span>
+          </template>
         </div>
       </div>
     </div>
@@ -165,6 +173,13 @@ export default Vue.component('oblique', {
         text-transform:uppercase;
         i {
           font-size:17px;
+        }
+      }
+      ul {
+        list-style-type:none;
+        i {
+          font-size:11px;
+          margin-right:6px;
         }
       }
     }

--- a/src/resumes/side-bar.vue
+++ b/src/resumes/side-bar.vue
@@ -53,7 +53,16 @@
                           <span class="time-period"> {{experience.timeperiod}}</span>
                       </div>
                       <div class="row">
-                          <span class="job-description"> {{experience.description}} </span>
+                          <span class="job-description"> 
+                            <template v-if="Array.isArray(experience.description)">
+                              <ul>
+                                <li v-for="bullet in experience.description"><span class="experience-text">{{bullet}}</span></li>
+                              </ul>
+                            </template>
+                            <template v-else>
+                              {{experience.description}}
+                            </template>
+                          </span>
                       </div>
                   </div>
           </div>
@@ -191,6 +200,12 @@ export default Vue.component('side-bar', {
       .row .job-title {
         font-size:19px;
       }
+      .row .job-description ul li {
+        color: rgba(153, 153, 153, 0.6);
+        .experience-text {
+          color:#000;
+        }
+      } 
     }
     .education {
       margin-top:50px;


### PR DESCRIPTION
## This PR contains:
added support to existing templates to list job description array items as bullet points. 

## Describe the problem you have without this PR
Prior to this PR, users had to format their job descriptions as a paragraph and could not format with bullet points. This solves that issue for the existing templates. 
I have also updated the CSS to match the list-style-type to the look and feel of each resume template. 

## How to use:
In your person.json file, add an array of job duties in your experience.description. It will format automatically into list items. Like so: 

```json
{  
   "experience":[  
      {  
         "company":"Company A",
         "position":"Developer",
         "timeperiod":"since January 2016",
         "description":[  
            "Programming and watching cute cat videos.",
            "Fulfillment of extremely important tasks.",
            "Making coffee and baking cookies."
         ]
      }
   ]
}
```

## Worth Noting:
A few of the templates break easily if you add too much content. Material-Dark, specifically, is broken by chrome-shadow-fixer fairly easily whether you use too much content in bullet-point form or in paragraph form. Just something to look at for ahead of time. 


Edit by @pubkey : Fix json-format
