### PR TITLE
Add npm commands to build and deploy to gh-pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "node build/dev-server.js",
     "build": "node build/build.js",
+    "gh-pages": "./node_modules/.bin/gh-pages -d dist",
+    "deploy:gh-pages": "npm run build && npm run gh-pages",
     "start": "node build/dev-server.js",
     "pdf": "node node/app.js",
     "template": "node node/template/template.js",
@@ -56,6 +58,7 @@
     "extract-text-webpack-plugin": "^2.1.2",
     "file-loader": "^0.11.1",
     "friendly-errors-webpack-plugin": "^1.1.3",
+    "gh-pages": "^1.0.0",
     "html-webpack-plugin": "^2.30.1",
     "http": "0.0.0",
     "http-proxy-middleware": "^0.17.3",


### PR DESCRIPTION
## This PR contains:
Npm scripts to build & deploy to gh-pages with 1 command
```
npm run deploy:gh-pages
```
This will build & deploy to gh-pages based on the origin remote you have setup. If it's a fork, it will be published to your fork.
The live link will be `https://{{fork-username}}.github.io/best-resume-ever`

Update: This is intended for forks mostly and is related to #18 which was partially solved. The base repo has CI and automatic deploy to gh-pages.

## Describe the problem you have without this PR
When you fork the repo and want to publish your resume to gh-pages, you have to do it manually by installing gh-pages package, building and running gh-pages commands.

