### PR TITLE
Add dynamic home

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -24,7 +24,9 @@ In the directory `src/resumes` you will find all existing templates.
 let name = 'TEMPLATE-NAME';
 ```
 
-3. Import the newly added template in `src/resumes/resumes.js`.
+3. Import the newly added template and add the name to the list in `src/resumes/resumes.js`.
+
+4. Place a preview image in `src/assets/preview/resume-TEMPLATE-NAME.png`.
 
 <br>
 Your new resume will be now reachable at localhost:8080/#/resume/TEMPLATE-NAME.

--- a/src/pages/home.vue
+++ b/src/pages/home.vue
@@ -6,35 +6,11 @@
   </div>
   <h3 class="title">best-resume-ever</h3>
   <div class="previews">
-    <div class="preview">
-      <router-link v-bind:to="'/resume/material-dark'">
+    <div class="preview" v-for="template in templates">
+      <router-link v-bind:to="'/resume/'+template">
         <div class="preview-wrapper">
-          <img src="../assets/preview/resume-material-dark.png" />
-          <span>material-dark</span>
-        </div>
-      </router-link>
-    </div>
-    <div class="preview">
-      <router-link v-bind:to="'/resume/left-right'">
-        <div class="preview-wrapper">
-          <img src="../assets/preview/resume-left-right.png" />
-          <span>left-right</span>
-        </div>
-      </router-link>
-    </div>
-    <div class="preview">
-      <router-link v-bind:to="'/resume/oblique'">
-        <div class="preview-wrapper">
-          <img src="../assets/preview/resume-oblique.png" />
-          <span>oblique</span>
-        </div>
-      </router-link>
-    </div>
-    <div class="preview">
-      <router-link v-bind:to="'/resume/side-bar'">
-        <div class="preview-wrapper">
-          <img src="../assets/preview/resume-side-bar.png" />
-          <span>side-bar</span>
+          <img v-bind:src="'../assets/preview/resume-'+template+'.png'" />
+          <span>{{ template }}</span>
         </div>
       </router-link>
     </div>
@@ -44,8 +20,15 @@
 
 <script>
 import Vue from 'vue';
+import { templates } from '../resumes/resumes';
+
 export default Vue.component('resume', {
-  name: 'app'
+  name: 'app',
+  data () {
+    return {
+      templates
+    };
+  }
 });
 </script>
 

--- a/src/resumes/resumes.js
+++ b/src/resumes/resumes.js
@@ -1,11 +1,19 @@
+import { PERSON } from '../person';
+import { terms } from '../terms';
+
 // If you create a new resume, import it here:
 import '../resumes/material-dark.vue';
 import '../resumes/left-right.vue';
 import '../resumes/oblique.vue';
 import '../resumes/side-bar.vue';
 
-import { PERSON } from '../person';
-import { terms } from '../terms';
+// and add it to the template list (for displaying on home)
+const templates = [
+  'material-dark',
+  'left-right',
+  'oblique',
+  'side-bar'
+];
 
 // Called by templates to decrease redundancy
 function getVueOptions (name) {
@@ -26,4 +34,4 @@ function getVueOptions (name) {
   return opt;
 }
 
-export { getVueOptions };
+export { getVueOptions, templates };


### PR DESCRIPTION
## This PR contains:
 - ENHANCEMENT

## Describe the problem you have without this PR
Shortly mentioned here: https://github.com/salomonelli/best-resume-ever/pull/5#issuecomment-329301836
The home overview with all templates has to be edited for every template which is added. To minimize redundancy, this can be done in a vue loop.

## To Do / Discussion
 - Written here https://github.com/salomonelli/best-resume-ever/issues/41#issuecomment-329518443, the images are not rendered. Maybe someone knows a solution?
 - If a new template is added, it has to be imported **and** added to a list in `src/resumes.js`. Can this be done better?