### PR TITLE
Language: add "about" heading

### DIFF
--- a/src/lang/cn.js
+++ b/src/lang/cn.js
@@ -4,7 +4,8 @@ const cn = {
     contact: '联系方式',
     experience: '工作经历',
     education: '教育经历',
-    skills: '技能专长'
+    skills: '技能专长',
+    about: '关于我'
   }
 };
 export default cn;

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -4,7 +4,8 @@ const de = {
     contact: 'Kontakt',
     experience: 'Berufserfahrung',
     education: 'Schulbildung',
-    skills: 'Qualifikationen'
+    skills: 'Qualifikationen',
+    about: 'Über mich'
   }
 };
 export default de;

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -4,7 +4,8 @@ const en = {
     contact: 'Contact',
     experience: 'Experience',
     education: 'Education',
-    skills: 'Skills'
+    skills: 'Skills',
+    about: 'About me'
   }
 };
 export default en;

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -4,7 +4,8 @@ const fr = {
     contact: 'Contact',
     experience: 'Expériences professionelles',
     education: 'Formation',
-    skills: 'Compétences'
+    skills: 'Compétences',
+    about: 'À propos de moi'
   }
 };
 export default fr;

--- a/src/lang/it.js
+++ b/src/lang/it.js
@@ -4,7 +4,8 @@ const it = {
     contact: 'Contatti',
     experience: 'Esperienza professionale',
     education: 'Formazione',
-    skills: 'Competenze'
+    skills: 'Competenze',
+    about: 'A proposito di me'
   }
 };
 export default it;

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -4,7 +4,8 @@ const pt = {
     contact: 'Contactos',
     experience: 'Experiência Profissional',
     education: 'Educação',
-    skills: 'Competências'
+    skills: 'Competências',
+    about: 'Sobre mim'
   }
 };
 export default pt;


### PR DESCRIPTION
## This PR contains:
- LANGUAGE UPDATE

## Describe the problem you have without this PR
For some templates (e.g. #53) an "about me" heading is needed

Please check the translations (I used google translator):
@sirLisko (Italian)
@hoganliu2016 (Chinese)
@kivS (Portuguese)
@salomonelli (French)

@salomonelli For such updates it would be good to have a default Englisch `term.js` to avoid empty headings. Or how do you want to handle that?
