### PR TITLE
Added support for brazilian portuguese localisation

### DIFF
--- a/src/lang/pt-br.js
+++ b/src/lang/pt-br.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+const ptbr = {
+  headings: {
+    contact: 'Contato',
+    experience: 'Experiência Profissional',
+    education: 'Educação',
+    skills: 'Competências',
+    about: 'Sobre'
+  }
+};
+export default ptbr;

--- a/src/person.js
+++ b/src/person.js
@@ -84,5 +84,5 @@ export const PERSON = {
     website: 'johndoe.com',
     github: 'johnyD'
   },
-  lang: 'en' // en, de, fr, pt, cn, it
+  lang: 'en' // en, de, fr, pt, cn, it, pt-br
 };

--- a/src/terms.js
+++ b/src/terms.js
@@ -4,7 +4,8 @@ import fr from './lang/fr';
 import pt from './lang/pt';
 import cn from './lang/cn';
 import it from './lang/it';
+import ptbr from './lang/pt-br';
 
 export const terms = {
-  en, de, fr, pt, cn, it
+  en, de, fr, pt, cn, it, 'pt-br': ptbr
 };


### PR DESCRIPTION
Thanks for this project!

## This PR contains:
Support for brazilian portuguese localisation 🇧🇷

## Describe the problem you have without this PR
Wanted to translate my resume into brazilian portuguese 😄

***

**Note:** Since the code used for ptbr usually is `pt-br` I've added this way so users don't get confused by having to use something like `ptbr`. This changed a bit from the way the other languages were being defined, hope it's not a big deal. I guess using `ptbr` wouldn't be a problem, just not usual.