### PR TITLE
Added Hebrew (HE) to the languages and improved the left-right template.

### DIFF
--- a/src/lang/he.js
+++ b/src/lang/he.js
@@ -1,0 +1,11 @@
+/* eslint-disable */
+const he = {
+  headings: {
+    contact: 'צור קשר',
+    experience: 'ניסיון',
+    education: 'השכלה',
+    skills: 'כישורים',
+    about: 'על אודותיי'
+  }
+};
+export default he;

--- a/src/person.js
+++ b/src/person.js
@@ -84,5 +84,5 @@ export const PERSON = {
     website: 'johndoe.com',
     github: 'johnyD'
   },
-  lang: 'en' // en, de, fr, pt, cn, it, es, th, pt-br, ru, sv, id, hu, pl
+  lang: 'en' // en, de, fr, pt, cn, it, es, th, pt-br, ru, sv, id, hu, pl, he
 };

--- a/src/resumes/left-right.vue
+++ b/src/resumes/left-right.vue
@@ -25,24 +25,24 @@
       <h3>{{ lang.headings.contact }}</h3>
       <table>
         <tr>
-          <td><a :href="'mailto:'+person.contact.email">{{person.contact.email}}</a></td>
           <td><i class="fa fa-envelope" aria-hidden="true"></i></td>
+          <td><a :href="'mailto:'+person.contact.email">{{person.contact.email}}</a></td>
         </tr>
         <tr>
-          <td><a :href="'tel:'+person.contact.phone">{{person.contact.phone}}</a></td>
           <td><i class="fa fa-phone" aria-hidden="true"></i></td>
+          <td><a :href="'tel:'+person.contact.phone">{{person.contact.phone}}</a></td>
         </tr>
         <tr>
-          <td>{{person.contact.street}} <br> {{person.contact.city}}</td>
           <td><i class="fa fa-home" aria-hidden="true"></i></td>
+          <td>{{person.contact.street}} <br> {{person.contact.city}}</td>
         </tr>
         <tr>
-          <td><a :href="person.contact.website">{{person.contact.website}}</a></td>
           <td><i class="fa fa-globe" aria-hidden="true"></i></td>
+          <td><a :href="person.contact.website">{{person.contact.website}}</a></td>
         </tr>
         <tr>
-          <td><a :href="'https://github.com/'+person.contact.github">https://github.com/{{person.contact.github}}</a></td>
           <td><i class="fa fa-github" aria-hidden="true"></i></td>
+          <td><a :href="'https://github.com/'+person.contact.github">https://github.com/{{person.contact.github}}</a></td>
         </tr>
       </table>
     </div>
@@ -83,6 +83,7 @@ export default Vue.component(name, getVueOptions(name));
   font-family:'Source Sans Pro', sans-serif;
   font-size:20px;
   padding-bottom:50px;
+  direction: rtl;
   a, a:focus, a:hover, a:visited {
     color:#616161;
   }
@@ -106,7 +107,7 @@ export default Vue.component(name, getVueOptions(name));
   }
   .half.right {
     float:right;
-    text-align:left;
+    text-align:right;
     padding-right:4%;
     padding-left:2%;
   }
@@ -196,6 +197,7 @@ export default Vue.component(name, getVueOptions(name));
   .skills {
     margin-top:20px;
     margin-bottom:10px;
+    direction: ltr !important;
     .skill-block {
       padding-bottom:10px;
       display:inline-block;
@@ -203,6 +205,7 @@ export default Vue.component(name, getVueOptions(name));
         width:100px;
         color:#616161;
         float:left;
+        text-align: left;
       }
       .skill-bar {
         float:right;

--- a/src/terms.js
+++ b/src/terms.js
@@ -12,7 +12,8 @@ import ru from './lang/ru';
 import ptbr from './lang/pt-br';
 import hu from './lang/hu';
 import pl from './lang/pl';
+import he from './lang/he';
 
 export const terms = {
-  en, de, fr, pt, cn, it, es, th, 'pt-br': ptbr, ru, sv, id, hu, pl
+  en, de, fr, pt, cn, it, es, th, 'pt-br': ptbr, ru, sv, id, hu, pl, he
 };


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

## This PR contains:

- Improved the left-right template to be a little more suitable. It now looks like this (with the person.js contents translated to Hebrew:
![left-right-after](https://user-images.githubusercontent.com/360928/31577217-44775870-b113-11e7-8c19-2ce32ec83be9.png)
- Added Hebrew (abbreviated as he) to the available languages.

This is further work on RTL templates, as described in issue #8 