### PR TITLE
Fix npm warnings (#28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.0",
   "description": "Build fast and easy multiple beautiful resumes and create your best CV ever! ",
   "author": "salomonelli",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/salomonelli/best-resume-ever.git"
+  },
   "scripts": {
     "dev": "node build/dev-server.js",
     "start": "node build/dev-server.js",


### PR DESCRIPTION
*In #28 resolution (see #29) I forget to commit the NPM warn part*

### Case

IS IT A: ENHANCEMENT

## Issue

On `npm install`, I found several issues:

* there is 2 warning
  ```
  npm WARN best-resume-ever@1.0.0 No repository field.
  npm WARN best-resume-ever@1.0.0 No license field.
  ```

Proposal: 
* update the package.json by adding the 2 missing fields.

## Info
- Operating System: OSX
- Node-Version: 5.4.1

## Reproduce

```sh
rm -rf node_modules
npm install
```