### PR TITLE
Fixing the empty PDF resumes

### DIFF
--- a/scripts/export.js
+++ b/scripts/export.js
@@ -44,7 +44,7 @@ const convert = async() => {
     directories.forEach(async(dir) => {
       const browser = await puppeteer.launch({args: ['--no-sandbox']});
       const page = await browser.newPage();
-      await page.goto('http://localhost:8080/#/resume/' + dir.name, {waitUntil: 'networkidle'});
+      await page.goto('http://localhost:8080/#/resume/' + dir.name, {waitUntil: 'networkidle', networkIdleTimeout: 5E3});
       await page.pdf({path: path.join(__dirname, '../pdf/' + dir.name + '.pdf'), format: 'A4'});
       await browser.close();
     });


### PR DESCRIPTION
## This PR contains:

🐞 BUGFIX: 
Based on doc below.
https://github.com/GoogleChrome/puppeteer/blob/v0.10.2/docs/api.md#pagegotourl-options
We seem to be hitting the default `networkIdleTimeout` of 1000ms while the template is still being built.

## Describe the problem you have without this PR
https://github.com/salomonelli/best-resume-ever/issues/109 
