### PR TITLE
Use the dev.port value from config/index.js vs. hard coding.

### DIFF
--- a/scripts/export.js
+++ b/scripts/export.js
@@ -3,11 +3,12 @@ const fs = require('fs');
 const path = require('path');
 const Rx = require('rxjs/Rx');
 const http = require('http');
+const config = require('../config');
 
 const fetchResponse = () => {
   return new Promise((res, rej) => {
     try {
-      const req = http.request('http://localhost:8080/#/', response => res(response.statusCode));
+      const req = http.request(`http://localhost:${config.dev.port}/#/`, response => res(response.statusCode));
       req.on('error', (err) => rej(err));
       req.end();
     } catch (err) {
@@ -46,7 +47,7 @@ const convert = async () => {
         args: ['--no-sandbox']
       });
       const page = await browser.newPage();
-      await page.goto('http://localhost:8080/#/resume/' + dir.name, {
+      await page.goto(`http://localhost:${config.dev.port}/#/resume/` + dir.name, {
         waitUntil: 'networkidle2'
       });
       await page.pdf({


### PR DESCRIPTION
## This PR contains:
ENHANCEMENT

## Describe the problem you have without this PR
Currently npm run export is hard coded to use port 8080. It would be nice to use the dev.port value from config/index.js instead. (Suggested in Issue 167.)
