### PR TITLE
Fix text direction error on sidebar of side-bar-rtl resume

### DIFF
--- a/src/resumes/side-bar-rtl.vue
+++ b/src/resumes/side-bar-rtl.vue
@@ -158,6 +158,7 @@ export default Vue.component(name, getVueOptions(name));
       text-align:center;
       letter-spacing:2px;
       margin-bottom:3px;
+      direction: ltr;
       a {
         color:black;
       }


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

## This PR contains:
- Change some CSS to fix text direction error

## Describe the problem you have without this PR
The text of the sidebar was inverted on side-bar-rtl template. For example, if you type "10 example street", it will display "example street 10".

<!--

IMPORTANT: READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- DO NOT ADD GENERATED FILES TO THE PULL-REQUEST (NOTHING FROM THE pdf-FOLDER)

-->
