### PR TITLE
ADD translation for 'Born' in pt-br

### DIFF
--- a/src/lang/pt-br.js
+++ b/src/lang/pt-br.js
@@ -1,4 +1,5 @@
 const lang = {
+  born: 'Nascido',
   contact: 'Contato',
   experience: 'Experiência Profissional',
   /* You can choose, "Educação" or "Formação Acadêmica"! But the second one is more professional and is more used. */


### PR DESCRIPTION
## This PR contains:
A translation for a word in pt-br.

## Describe the problem you have without this PR
when generating a resume in pt-br, the field with 'born' was generated in english, I've simply put a translation for born.
