### PR TITLE
Fix missing `name` variable

### DIFF
--- a/src/resumes/purple.vue
+++ b/src/resumes/purple.vue
@@ -67,7 +67,8 @@
 import Vue from 'vue';
 import { getVueOptions } from './options';
 
-export default Vue.component('purple', getVueOptions(name));
+let name = 'purple';
+export default Vue.component(name, getVueOptions(name));
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
The function `getVueOptions` is called with a null `name`. 