### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ dist: trusty
 os:
   - linux
 node_js:
-  - "10.6.0"
+  - "node"
+  - "10"
 
 before_install:
   - export CHROME_BIN=chromium-browser


### PR DESCRIPTION
<!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->

## This PR contains:
CI improvement
<!--
 - IMPROVED DOCS
 - A TYPO-FIX
 - A BUGFIX
 - A NEW FEATURE
 - A BREAKING CHANGE
 - SOMETHING ELSE
-->

## Describe the problem you have without this PR
<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->

<!--

IMPORTANT: READ THIS BEFORE SUBMISSION:

- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
- DO NOT ADD GENERATED FILES TO THE PULL-REQUEST (NOTHING FROM THE pdf-FOLDER)

-->


Test Node.js LTS (8 and 10) and also current stable (11).