### PR TITLE
fix: won't crash if pdf output folder doesn't exist

### DIFF
--- a/scripts/export.js
+++ b/scripts/export.js
@@ -52,7 +52,7 @@ const convert = async () => {
     console.log('Connected to server ...');
     console.log('Exporting ...');
     try {
-        const relativePdfDirectoryPath = '../pdf/';
+        const fullDirectoryPath = path.join(__dirname, '../pdf/');
         const directories = getResumesFromDirectories();
         directories.forEach(async (dir) => {
             const browser = await puppeteer.launch({
@@ -64,15 +64,12 @@ const convert = async () => {
             });
 
             if (
-                !fs.existsSync(path.join(__dirname, relativePdfDirectoryPath))
+                !fs.existsSync(fullDirectoryPath)
             ) {
-                fs.mkdirSync(path.join(__dirname, relativePdfDirectoryPath));
+                fs.mkdirSync(fullDirectoryPath);
             }
             await page.pdf({
-                path: path.join(
-                    __dirname,
-                    relativePdfDirectoryPath + dir.name + '.pdf'
-                ),
+                path: fullDirectoryPath + dir.name + '.pdf',
                 format: 'A4'
             });
             await browser.close();

--- a/scripts/export.js
+++ b/scripts/export.js
@@ -52,6 +52,7 @@ const convert = async () => {
     console.log('Connected to server ...');
     console.log('Exporting ...');
     try {
+        const relativePdfDirectoryPath = '../pdf/';
         const directories = getResumesFromDirectories();
         directories.forEach(async (dir) => {
             const browser = await puppeteer.launch({
@@ -61,8 +62,17 @@ const convert = async () => {
             await page.goto(`http://localhost:${config.dev.port}/#/resume/` + dir.name, {
                 waitUntil: 'networkidle2'
             });
+
+            if (
+                !fs.existsSync(path.join(__dirname, relativePdfDirectoryPath))
+            ) {
+                fs.mkdirSync(path.join(__dirname, relativePdfDirectoryPath));
+            }
             await page.pdf({
-                path: path.join(__dirname, '../pdf/' + dir.name + '.pdf'),
+                path: path.join(
+                    __dirname,
+                    relativePdfDirectoryPath + dir.name + '.pdf'
+                ),
                 format: 'A4'
             });
             await browser.close();

--- a/test/scripts/deleteFiles.js
+++ b/test/scripts/deleteFiles.js
@@ -21,5 +21,6 @@ fs.readdir(directory, (err, files) => {
       if (err) throw err;
     });
   }
+  fs.rmdirSync(directory);
   console.log('Deleted files.');
 });


### PR DESCRIPTION
## This PR contains:
 - a bugfix

## Describe the problem you have without this PR
Fixes #343