### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ git clone https://github.com/salomonelli/best-resume-ever.git
 
 4. Customize your resume in the `resume/` directory: edit your data `data.yml` and replace the default profile-picture `id.jpg` with your picture. Rename your picture as `id.jpg` and copy it in the `resume/` directory.
 
-5. Preview resumes with `npm run dev`. The command will start a server instance and listen on port 8080.  Open (http://localhost:8080/) in your browser. The page will show some resume previews. To see the preview of your resume, with your picture and data, click on one layout that you like and the resume will be opened in the same window.
+5. Preview resumes with `npm run dev`. The command will start a server instance and listen on port 8080.  Open (http://localhost:8080/home) in your browser. The page will show some resume previews. To see the preview of your resume, with your picture and data, click on one layout that you like and the resume will be opened in the same window.
 
 ![Resume previews](/readme-images/resumePreviews.png)
 


### PR DESCRIPTION
fix incorrect url

## This PR contains:
 - IMPROVED DOCS

## Describe the problem you have without this PR
Fixes incorrect url in README.md - `localhost:8080/` does not display the selection of resume previews as stated.
