### PR TITLE
Born, BornIn italian localization

### DIFF
--- a/src/lang/it.js
+++ b/src/lang/it.js
@@ -1,6 +1,8 @@
 // Italian
 const lang = {
     contact: 'Contatti',
+    born: 'Nato nel',
+    bornIn: 'a',
     experience: 'Esperienza professionale',
     education: 'Formazione',
     skills: 'Competenze',


### PR DESCRIPTION
## This PR contains:
 - A TYPO-FIX

## Describe the problem you have without this PR
'Born" and "BornIn" fields were missing in italian localization

