### PR TITLE
Remove forced uppercase for person.name.last || Creative.vue

### DIFF
--- a/src/resumes/creative.vue
+++ b/src/resumes/creative.vue
@@ -4,7 +4,7 @@
       <div>
         <div class="headline">
           <span> {{ person.name.first }} {{ person.name.middle }} </span>
-          <span class="uppercase"> {{ person.name.last }} </span>
+          <span> {{ person.name.last }} </span>
         </div>
 
         <p>


### PR DESCRIPTION
## This PR contains:

An improvement on the Creative.vue template

## Describe the problem you have without this PR

The Creative.vue template forces uppercase on the last name of the person. That makes the name look inconsistent as neither first name or middle name are uppercase by default. Removing `class="uppercase"` allows the user to choose whether they want their last name to be in uppercase or not. Currently the last name will **always** be in uppercase.

