### PR TITLE
Removed <span> and <div> on Vue resume page.

### DIFF
--- a/src/resumes/creative.vue
+++ b/src/resumes/creative.vue
@@ -3,8 +3,7 @@
     <div class="left-column">
       <div>
         <div class="headline">
-          <span> {{ person.name.first }} {{ person.name.middle }} </span>
-          <span class="uppercase"> {{ person.name.last }} </span>
+          <span> {{ person.name.first }} {{ person.name.middle }} {{ person.name.last }}</span>
         </div>
 
         <p>
@@ -78,7 +77,6 @@
       </div>
 
       <div class="hobbies-container">
-        <!-- <span class="subheadline">Hobbies</span> -->
         <div class="hobbies-content">
           <a v-for="(hobby, index) in person.hobbies" :key="index"
             class="hobby-item"


### PR DESCRIPTION
Design looks better with <span> {{person.name.last}} included on same line as first and middle. Also removed <div> comment which was outdated.

## This PR contains:

 - IMPROVED DOCS
 - A TYPO-FIX
 - A NEW FEATURE


## Describe the problem you have without this PR
-->
Less organized resume. Removed outdated comment.
