### PR TITLE
Abkamand template edits

### DIFF
--- a/src/resumes/left-right-projects.vue
+++ b/src/resumes/left-right-projects.vue
@@ -241,8 +241,9 @@ export default Vue.component(name, getVueOptions(name));
                 height: 8px;
                 border-radius: 3px;
                 margin-top: 6.5px;
+                margin-left:60px;
                 position: relative;
-                width: 249px;
+                width: 150px;
                 .level {
                     background: #757575;
                     height: 100%;

--- a/src/resumes/left-right-rtl.vue
+++ b/src/resumes/left-right-rtl.vue
@@ -213,8 +213,9 @@ export default Vue.component(name, getVueOptions(name));
         height:8px;
         border-radius:3px;
         margin-top:6.5px;
+        margin-left:60px;
         position:relative;
-        width:249px;
+        width:150px;
         .level {
           background:#757575;
           height:100%;

--- a/src/resumes/left-right.vue
+++ b/src/resumes/left-right.vue
@@ -211,8 +211,9 @@ export default Vue.component(name, getVueOptions(name));
         height:8px;
         border-radius:3px;
         margin-top:6.5px;
+        margin-left:60px;
         position:relative;
-        width:249px;
+        width:150px;
         .level {
           background:#757575;
           height:100%;

--- a/src/resumes/oblique-projects.vue
+++ b/src/resumes/oblique-projects.vue
@@ -163,7 +163,7 @@ export default Vue.component(name, getVueOptions(name));
         }
     }
     .resume-content {
-        margin-top: 250px;
+        margin-top: 325px;
         margin-left: 15%;
         width: 70%;
         .experience .experience-block {

--- a/src/resumes/oblique-rtl.vue
+++ b/src/resumes/oblique-rtl.vue
@@ -16,6 +16,7 @@
   </div>
   <div class="resume-content">
     <div class="experience">
+      <div class="about">{{person.about}}</div>
       <h3>{{ lang.experience }}</h3>
       <div class="experience-block" v-for="experience in person.experience" :key="experience.company">
         <div class="row">

--- a/src/resumes/oblique-rtl.vue
+++ b/src/resumes/oblique-rtl.vue
@@ -104,13 +104,13 @@ export default Vue.component(name, getVueOptions(name));
         border-color: #006064 transparent transparent transparent;
         position: absolute;
         right: -600px;
-        top: 0;
+        top: -140px;
     }
     .resume-header .person-header {
         position: absolute;
         z-index: 20;
         left: 15%;
-        top: 200px;
+        top: 50px;
         .person-wrapper {
             overflow: hidden;
             position: relative;
@@ -148,7 +148,7 @@ export default Vue.component(name, getVueOptions(name));
         }
     }
     .resume-content {
-        margin-top: 435px;
+        margin-top: 400px;
         margin-right: 15%;
         width: 70%;
         .experience .experience-block {

--- a/src/resumes/oblique.vue
+++ b/src/resumes/oblique.vue
@@ -110,7 +110,7 @@ export default Vue.component(name, getVueOptions(name));
     position:absolute;
     z-index:20;
     right:15%;
-    top:50px;
+    top:30px;
     .person-wrapper {
       overflow:hidden;
       position:relative;
@@ -151,7 +151,7 @@ export default Vue.component(name, getVueOptions(name));
     font-weight:bold;
   }
   .resume-content {
-    margin-top:435px;
+    margin-top:480px;
     margin-left:15%;
     width:70%;
     .about {


### PR DESCRIPTION
## This PR contains:
<!--
 - Fixes and edits to left-right-projects.vue, oblique-projects.vue, oblique-rtl.vue, and oblique.vue templates.
-->

## Describe the problem you have without this PR
<!-- 
-oblique-rtl was missing the "about" section that is present in every other resume template
-oblique-rtl did not closely match the original template's header/body visual w/ respect to margins
-eliminated some excess white space and fixed bleeding across a few templates (i.e. body text bleeding into header)
-fixed left-right templates' skill bars bleeding/overlapping onto skill description text
 -->