### PR TITLE
Add option to export a single template

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -33,9 +33,11 @@ Your new resume will be now reachable at localhost:8080/#/resume/TEMPLATE-NAME.
 
 5. Export resumes as PDF with `npm run export`. Verify export of new template.
 
-4. Generate previews by converting PDF-files to PNG-files with `npm run preview`.
+    Alternatively, export a single resume with `npm run export --template=TEMPLATE_NAME`.
 
-5. Add preview to `/src/pages/home.vue`:
+6. Generate previews by converting PDF-files to PNG-files with `npm run preview`.
+
+7. Add preview to `/src/pages/home.vue`:
 ```javascript
 <div class="preview">
   <router-link v-bind:to="'/resume/TEMPLATE-NAME'">

--- a/scripts/export.js
+++ b/scripts/export.js
@@ -94,8 +94,20 @@ const getResumesFromDirectories = () => {
 
 const getDirectories = () => {
     const srcpath = path.join(__dirname, '../src/resumes');
-    return fs.readdirSync(srcpath)
-    .filter(file => file !== 'resumes.js' && file !== 'template.vue' && file !== 'options.js');
+    if (process.env.npm_config_template) {
+        const templateFile = process.env.npm_config_template + '.vue';
+        const templatePath = path.join(srcpath, templateFile);
+        try {
+            fs.accessSync(templatePath);
+        } catch (err) {
+            console.error(`Export error: no such template, '${templateFile}'`);
+            throw err;
+        }
+        return [templateFile];
+    } else {
+        return fs.readdirSync(srcpath)
+            .filter(file => !['resumes.js', 'template.vue', 'options.js'].includes(file));
+    }
 };
 
 convert();


### PR DESCRIPTION
## This PR contains:

- an enhancement

## Describe the problem you have without this PR

The export script is very memory-hungry because it creates as many instances of a Chromium browser as there are templates. My laptop's memory is often on the verge of a freeze, and that's often the case when I run export on this project.

There's room for optimizing that by launching a single instance of Chromium and opening a number of tabs/pages. In the meantime, here's a pretty simple workaround that allows a single template export by setting an option in the terminal:

```bash
npm run export --template=TEMPLATE_NAME
```