### PR TITLE
README Update to Address Error:0308010C 

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ git clone https://github.com/salomonelli/best-resume-ever.git
 <b>Note</b>: If you encounter `Error: error:0308010C:digital envelope routines::unsupported` use the following commands and run `run npm dev` again:
 
 `export NODE_OPTIONS=--openssl-legacy-provider`
-`export NODE_OPTIONS=--openssl-legacy-provider` (for Windows users)
+<br> `export NODE_OPTIONS=--openssl-legacy-provider` (for Windows users)
 
 The error message pertains to a vulnerability in a previous Node.js that has since been addressed. These commands will not downgrade your Node.js.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ git clone https://github.com/salomonelli/best-resume-ever.git
 
 ![Resume previews](/readme-images/resumePreviews.png)
 
+<b>Note</b>: If you encounter `Error: error:0308010C:digital envelope routines::unsupported` use the following commands and run `run npm dev` again:
+
+`export NODE_OPTIONS=--openssl-legacy-provider`
+`export NODE_OPTIONS=--openssl-legacy-provider` (for Windows users)
+
+The error message pertains to a vulnerability in a previous Node.js that has since been addressed. These commands will not downgrade your Node.js.
 
 6. Export your resume as pdf by running the command `npm run export`. In order to avoid errors due to the concurrency of two  `npm run` commands, stop the execution of the previus `npm run dev` and then type the export command.
 


### PR DESCRIPTION
## This PR contains:
Improved documentation to address an issue when attempting to generate a resume

## Describe the problem you have without this PR
When using the command 'npm run dev', it results in an error, `error:0308010C:` and unable to preview resume
