### PR TITLE
Updated readme to show users how to use program without downgrading node.js

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,7 @@
 <!-- REMOVE EVERYTHING WRITTEN IN UPPERCASE -->
 
 ## This PR contains:
-<!--
- - IMPROVED DOCS
- - A TYPO-FIX
- - A BUGFIX
- - A NEW FEATURE
- - A BREAKING CHANGE
- - SOMETHING ELSE
--->
+Improved Docs
 
 ## Describe the problem you have without this PR
-<!-- DESCRIBE PROBLEM HERE OR LINK TO AN ISSUE -->
-
-<!--
-
-IMPORTANT: READ THIS BEFORE SUBMISSION:
-
-- IF YOUR PULL-REQUEST CONTAINS A NEW FEATURE, IT MUST HAVE BEEN DISCUSSED AT AN ISSUE BEFORE
-- DO NOT ADD GENERATED FILES TO THE PULL-REQUEST (NOTHING FROM THE pdf-FOLDER)
-
--->
+Added a workaround in the readme for users to be able to use npm dev without downgrading their node.vs version

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ git clone https://github.com/salomonelli/best-resume-ever.git
 
 4. Customize your resume in the `resume/` directory: edit your data `data.yml` and replace the default profile-picture `id.jpg` with your picture. Rename your picture as `id.jpg` and copy it in the `resume/` directory. During this step, you may find it easier to navigate with Finder or File Explorer to get to the files. This will allow you to edit files with your computers default text editor. 
 
-5. Preview resumes with `npm run dev`. The command will start a server instance and listen on port 8080.  Open (http://localhost:8080/home) in your browser. The page will show some resume previews. To see the preview of your resume, with your picture and data, click on one layout that you like and the resume will be opened in the same window.
+5. Preview resumes with `$env:NODE_OPTIONS="--openssl-legacy-provider"` then use`npm run dev`. The above command is necessary for newer versions of nodejs to function with this program. The command will start a server instance and listen on port 8080.  Open (http://localhost:8080/home) in your browser. The page will show some resume previews. To see the preview of your resume, with your picture and data, click on one layout that you like and the resume will be opened in the same window.
 
 ![Resume previews](/readme-images/resumePreviews.png)
 


### PR DESCRIPTION
## This PR contains:
Improved Docs

## Describe the problem you have without this PR
Added a workaround in the readme for users to be able to use npm dev without downgrading their node.vs version
