### PR TITLE
node 18, add avif, webp support, declare `@babel/runtime` as a dependency

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-14.21.2
+lts/hydrogen

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -45,7 +45,7 @@ module.exports = {
         include: [resolve('src'), resolve('test')]
       },
       {
-        test: /\.(png|jpe?g|gif|svg)(\?.*)?$/,
+        test: /\.(png|jpe?g|gif|svg|webp|avif)(\?.*)?$/,
         loader: 'url-loader',
         options: {
           limit: 10000,

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "scripts": {
     "docs": "node build/build.js",
     "docs:serve": "cd docs/ && ws --port 8080 --rewrite '/best-resume-ever/* -> /$1'",
-    "dev": "node build/dev-server.js",
-    "start": "node build/dev-server.js",
+    "dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider node build/dev-server.js",
+    "start": "npm run dev",
     "pdf": "node scripts/export.js",
     "preview": "node scripts/preview.js",
     "test:deleteFiles": "node test/scripts/deleteFiles.js",
@@ -27,6 +27,7 @@
     "lint:fix": "eslint --ext .js,.vue src scripts --fix"
   },
   "dependencies": {
+    "@babel/runtime": "7.1.5",
     "font-awesome": "4.7.0",
     "js-yaml": "3.13.1",
     "material-design-icons": "3.0.1",
@@ -53,6 +54,7 @@
     "connect-history-api-fallback": "1.5.0",
     "copy-webpack-plugin": "4.5.2",
     "cpx": "1.5.0",
+    "cross-env": "7.0.3",
     "css-loader": "1.0.0",
     "escope": "3.6.0",
     "eslint": "5.6.0",


### PR DESCRIPTION
- Upgrade to Node 18. Node 14 is officially long dead. You have to use `--openssl-legacy-provider` option to make it work
- I tried to use project with `pnpm` and it has errors unless `@babel/runtime` is explicitly defined. I believe, because `@babel/runtime` is a real dependency and is really injected by babel - it would be nice to explicitly declare that this package is injected into code. It's a runtime dependency, not build time, thus adding it to `dependencies` object rather than `devDependencies`
- Add webp and avif images support. Very common format nowadays: [avif](https://caniuse.com/avif), [webp](https://caniuse.com/webp)